### PR TITLE
fix issue of classFor. (causes ExceptionInInitializerError)

### DIFF
--- a/src/main/frege/frege/nativegen/Main.fr
+++ b/src/main/frege/frege/nativegen/Main.fr
@@ -1,6 +1,6 @@
 module frege.nativegen.Main where
 
-import frege.Prelude hiding (Class)
+import frege.Prelude hiding (Class, ClassLoader)
 import frege.nativegen.NativeGen
 import frege.nativegen.java.Lang
 import Data.Map as M()

--- a/src/main/frege/frege/nativegen/NativeGen.fr
+++ b/src/main/frege/frege/nativegen/NativeGen.fr
@@ -1,6 +1,6 @@
 module frege.nativegen.NativeGen where
 
-import frege.Prelude hiding (Class)
+import frege.Prelude hiding (Class, ClassLoader)
 import frege.nativegen.java.Reflect
 import frege.nativegen.java.Lang
 import frege.nativegen.java.IO

--- a/src/main/frege/frege/nativegen/java/Lang.fr
+++ b/src/main/frege/frege/nativegen/java/Lang.fr
@@ -1,6 +1,6 @@
 module frege.nativegen.java.Lang where
 
-import frege.Prelude hiding (Class)
+import frege.Prelude hiding (Class, ClassLoader)
 
 data Class a = pure native java.lang.Class where
     pure  native getName    :: Class a -> String
@@ -71,10 +71,10 @@ classFor "float" = return . Just $ floatClass
 classFor "double" = return . Just $ doubleClass
 classFor "void" = return . Just $ voidClass
 classFor s = do
-    sys   <- JavaClassLoader.getSystemClassLoader 
-    either (const Nothing) Just <$> JavaClassLoader.loadClass sys s
+    sys   <- ClassLoader.getSystemClassLoader
+    either (const Nothing) Just <$> sys.loadClass s
 
-data JavaClassLoader = mutable native java.lang.ClassLoader where
+data ClassLoader = mutable native java.lang.ClassLoader where
     native loadClass :: ClassLoader -> String -> IO (ClassNotFoundException | Class a)
     native getSystemClassLoader "java.lang.ClassLoader.getSystemClassLoader()" :: IO ClassLoader
 

--- a/src/main/frege/frege/nativegen/java/Reflect.fr
+++ b/src/main/frege/frege/nativegen/java/Reflect.fr
@@ -1,6 +1,6 @@
 module frege.nativegen.java.Reflect where
 
-import frege.Prelude hiding (Class)
+import frege.Prelude hiding (Class, ClassLoader)
 import frege.nativegen.java.Lang
 
 data TypeVariable = pure native java.lang.reflect.TypeVariable where


### PR DESCRIPTION
When I used native-gen to the eclipse-jdt jars (AST Parsers),  following error occured:

> Exception in thread "main" java.lang.ExceptionInInitializerError
>         at java.lang.Class.forName0(Native Method)
>         at java.lang.Class.forName(Class.java:259)
>         at frege.nativegen.java.Lang.eval(Lang.java:831)
> ...

"ExceptionInInitializerError" is raised when the static initializer failed.
And above dump is caused by Class.forName in function classFor.

  According to http://stackoverflow.com/a/7099453,  the method "java.lang.Class.forName" calls
static initializer 'clinit' on loading the classes, and the native-gen uses 'java.lang.Class' object
only for metainfo, thus, I think this behavior won't be necessary.
  In contrast, the "java.lang.ClassLoader.loadClass" doesn't call 'clinit', and I suppose it will be better.

Thank you for reading this.
